### PR TITLE
Add agent-friendly CLI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,6 +24,6 @@ jobs:
       - name: Format check
         run: pnpm format:check
       - name: Test
-        run: pnpm test --passWithNoTests
+        run: pnpm test
       - name: Build
         run: pnpm build

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,6 +24,6 @@ jobs:
       - name: Format check
         run: pnpm format:check
       - name: Test
-        run: pnpm test -- --passWithNoTests
+        run: pnpm test --passWithNoTests
       - name: Build
         run: pnpm build

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -78,6 +78,18 @@ When building APIs after looking at requests and responses, follow the following
   - **Scope**: Exercise real GraphQL endpoints; prefer simple, robust expectations to handle live data variance.
   - **Naming**: Group by feature (e.g., `describe('integration: accounts', ...)`).
 
+# Building the CLI
+
+This package publishes the `monarch-money` CLI from `src/cli`.
+
+- Keep CLI command inputs as a single JSON payload.
+- Keep command outputs as JSON success/error envelopes.
+- Reuse exported library Zod input/output schemas in the CLI schema registry whenever possible.
+- Define reusable API input schemas in the domain `*.types.ts` file, not in `src/cli`.
+- Use CLI-only wrapper schemas only when adapting multiple library function arguments into one JSON payload.
+- Keep command `--help` compact by listing named schemas; expose full schemas through `monarch-money schemas list` and `monarch-money schemas get <name>`.
+- Auth state should cache only session token metadata. Never cache passwords or TOTP secrets.
+
 # Publishing
 
 This package is published to npm automatically via CI when a version tag is pushed.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,21 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/), and this project adheres to [Semantic Versioning](https://semver.org/).
 
+## [Unreleased]
+
+### Added
+
+- `monarch-money` CLI executable with JSON input/output commands for the existing API surface
+- Stateful CLI authentication with `auth login`, `auth status`, `auth logout`, and configurable `MONARCH_AUTH_FILE`
+- CLI JSON Schema registry via `schemas list` and `schemas get <name>`
+- Exported Zod input schemas for accounts, transactions, budgets, portfolio, and transaction rule preview APIs
+- CLI documentation in `CLI.md`
+
+### Changed
+
+- Moved `commander` to runtime dependencies for the published CLI
+- Documented CLI and reusable input schema conventions
+
 ## [0.1.0] - 2026-04-08
 
 ### Added

--- a/CLI.md
+++ b/CLI.md
@@ -1,0 +1,147 @@
+# Monarch Money CLI
+
+The `monarch-money-ts` package installs a `monarch-money` executable for scriptable access to the library APIs.
+
+The CLI is designed for automation and AI agents:
+
+- Commands use conventional subcommands.
+- Command inputs are JSON.
+- Command outputs are JSON envelopes.
+- Help is compact and references named schemas.
+- Full JSON Schemas are available through the schema registry.
+
+## Installation
+
+```bash
+npm install -g monarch-money-ts
+monarch-money --help
+```
+
+For local development:
+
+```bash
+pnpm build
+pnpm cli -- --help
+```
+
+## Authentication
+
+The CLI resolves authentication in this order:
+
+1. `MONARCH_TOKEN`
+2. `MONARCH_EMAIL` and `MONARCH_PASSWORD` with optional `MONARCH_OTP_KEY`
+3. Cached token from the auth state file
+
+Log in once and cache the session token:
+
+```bash
+monarch-money auth login
+```
+
+The default auth state file is:
+
+```text
+~/.monarch-money/auth.json
+```
+
+Set `MONARCH_AUTH_FILE` to share auth state across projects or sandboxes:
+
+```bash
+export MONARCH_AUTH_FILE="$HOME/.config/monarch-money/auth.json"
+monarch-money auth login
+```
+
+The auth state file stores only session token metadata. It does not store the password or TOTP secret.
+
+Inspect or clear auth state:
+
+```bash
+monarch-money auth status
+monarch-money auth logout
+```
+
+## Input and Output
+
+Pass command input as a single JSON argument:
+
+```bash
+monarch-money transactions list '{"limit":10}'
+monarch-money transactions get '{"id":"TRANSACTION_ID"}'
+monarch-money budget report '{"startDate":"2026-05-01","endDate":"2026-05-31"}'
+```
+
+Use `-` to read JSON from stdin:
+
+```bash
+printf '%s' '{"limit":10}' | monarch-money transactions list -
+```
+
+Successful commands return:
+
+```json
+{
+  "ok": true,
+  "data": {}
+}
+```
+
+Failed commands return:
+
+```json
+{
+  "ok": false,
+  "error": {
+    "code": "AUTH_REQUIRED",
+    "message": "Run `monarch-money auth login`, set MONARCH_TOKEN, or set MONARCH_EMAIL and MONARCH_PASSWORD with optional MONARCH_OTP_KEY."
+  }
+}
+```
+
+## Schemas
+
+Leaf command help shows named input and output schemas:
+
+```bash
+monarch-money transactions list --help
+```
+
+List all schemas:
+
+```bash
+monarch-money schemas list
+```
+
+Print a schema:
+
+```bash
+monarch-money schemas get input.transactions.list
+monarch-money schemas get output.transactions.list
+```
+
+Reusable input schemas live in the library type modules next to their inferred TypeScript types. CLI-only wrapper schemas are used only when a command needs to adapt multiple library arguments into one JSON input object.
+
+## Commands
+
+```bash
+monarch-money accounts list [input]
+
+monarch-money transactions list [input]
+monarch-money transactions get [input]
+monarch-money transactions update [input]
+
+monarch-money categories list
+monarch-money categories groups
+monarch-money categories get [input]
+
+monarch-money budget report [input]
+monarch-money budget status
+monarch-money budget settings
+
+monarch-money portfolio [input]
+
+monarch-money rules list
+monarch-money rules preview [input]
+
+monarch-money schemas list
+monarch-money schemas get <name>
+```

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -46,6 +46,7 @@ pnpm test:integration
 
 ```
 src/
+  cli/             # Published monarch-money CLI
   *.types.ts      # Zod schemas, TypeScript types, and GraphQL field constants
   *.api.ts        # API functions (one per domain)
   *.int.test.ts   # Integration tests
@@ -87,9 +88,19 @@ The coding conventions in `AGENTS.md` guide the agent through all of this. If yo
 
 - Use `.strict()` on Zod object schemas
 - Express nullability with `.nullable()` at the property level
+- Define reusable API input schemas as exported Zod schemas next to their inferred TypeScript types
 - Define `*_FIELDS` constants alongside schemas for GraphQL field selection
 - Validate all GraphQL responses with Zod before returning
 - Summary types (lightweight versions used in other responses) go in `common.types.ts` with a `*Summary` suffix
+
+## CLI Conventions
+
+- Keep the published CLI in `src/cli/`
+- Commands should accept at most one JSON input payload
+- Commands should return JSON success/error envelopes
+- Reuse library input/output Zod schemas in the CLI schema registry whenever possible
+- Use CLI-only wrapper schemas only to adapt multiple library arguments into one JSON input payload
+- Keep command help compact; expose full schemas through `monarch-money schemas list` and `monarch-money schemas get <name>`
 
 ## Submitting Changes
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Monarch Money TypeScript API
+# Monarch Money TypeScript API & CLI
 
 [npm version](https://www.npmjs.com/package/monarch-money-ts)
 [CI](https://github.com/chernetsov/monarch-money-ts/actions/workflows/ci.yml)

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # Monarch Money TypeScript API
 
-[![npm version](https://img.shields.io/npm/v/monarch-money-ts.svg)](https://www.npmjs.com/package/monarch-money-ts)
-[![CI](https://github.com/chernetsov/monarch-money-ts/actions/workflows/ci.yml/badge.svg)](https://github.com/chernetsov/monarch-money-ts/actions/workflows/ci.yml)
-[![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
+[npm version](https://www.npmjs.com/package/monarch-money-ts)
+[CI](https://github.com/chernetsov/monarch-money-ts/actions/workflows/ci.yml)
+[License: MIT](https://opensource.org/licenses/MIT)
 
 An unofficial TypeScript client for the [Monarch Money](https://www.monarchmoney.com/) API with comprehensive Zod-validated types.
 
@@ -15,6 +15,19 @@ npm install monarch-money-ts
 # or
 pnpm add monarch-money-ts
 ```
+
+## CLI
+
+The package also installs a `monarch-money` executable for scriptable access to the same APIs:
+
+```bash
+npx monarch-money-ts --help
+monarch-money accounts list
+monarch-money transactions list '{"limit":10}'
+monarch-money schemas get input.transactions.list
+```
+
+The CLI uses JSON input and JSON output, supports stateful token caching with `monarch-money auth login`, and exposes named JSON Schemas for command inputs and outputs. See [CLI.md](./CLI.md) for the full CLI guide.
 
 ## Quick Start
 
@@ -105,10 +118,17 @@ Contributions to expand coverage are welcome! See [CONTRIBUTING.md](./CONTRIBUTI
 
 ## Type System
 
-The library exports both Zod schemas and inferred TypeScript types for all API responses:
+The library exports Zod schemas and inferred TypeScript types for API responses and reusable API inputs:
 
 ```typescript
-import { type Account, AccountSchema, type Transaction, TransactionSchema } from 'monarch-money-ts';
+import {
+  type Account,
+  AccountSchema,
+  AccountFiltersInputSchema,
+  type Transaction,
+  TransactionSchema,
+  GetTransactionsOptionsSchema,
+} from 'monarch-money-ts';
 ```
 
 ## How This Library Is Built

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
   "scripts": {
     "build": "tsc",
     "cli": "tsx src/cli/index.ts",
-    "test": "vitest --run --passWithNoTests",
+    "test": "vitest --run",
     "test:integration": "vitest --run -c vitest.integration.config.ts",
     "lint": "eslint src/",
     "lint:fix": "eslint src/ --fix",

--- a/package.json
+++ b/package.json
@@ -6,9 +6,13 @@
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "type": "module",
+  "bin": {
+    "monarch-money": "dist/cli/index.js"
+  },
   "scripts": {
     "build": "tsc",
-    "test": "vitest --run",
+    "cli": "tsx src/cli/index.ts",
+    "test": "vitest --run --passWithNoTests",
     "test:integration": "vitest --run -c vitest.integration.config.ts",
     "lint": "eslint src/",
     "lint:fix": "eslint src/ --fix",
@@ -18,12 +22,14 @@
     "mmtraf": "tsx tools/mmtraf.ts"
   },
   "files": [
-    "dist"
+    "dist",
+    "CLI.md"
   ],
   "keywords": [
     "monarch",
     "money",
-    "api"
+    "api",
+    "cli"
   ],
   "author": "Mikhail Chernetsov",
   "bugs": {
@@ -36,16 +42,17 @@
   "homepage": "https://github.com/chernetsov/monarch-money-ts",
   "license": "MIT",
   "dependencies": {
+    "commander": "^12.1.0",
     "graphql-request": "^7.2.0",
     "node-fetch": "^3.3.2",
     "totp-generator": "^2.0.0",
-    "zod": "^3.25.76"
+    "zod": "^3.25.76",
+    "zod-to-json-schema": "^3.25.2"
   },
   "devDependencies": {
     "@eslint/js": "^10.0.1",
     "@types/node": "^20.0.0",
     "@vitest/coverage-v8": "^1.0.0",
-    "commander": "^12.1.0",
     "dotenv": "^17.2.0",
     "eslint": "^10.2.0",
     "eslint-config-prettier": "^10.1.8",

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
   "scripts": {
     "build": "tsc",
     "cli": "tsx src/cli/index.ts",
-    "test": "vitest --run",
+    "test": "vitest --run --passWithNoTests",
     "test:integration": "vitest --run -c vitest.integration.config.ts",
     "lint": "eslint src/",
     "lint:fix": "eslint src/ --fix",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,6 +8,9 @@ importers:
 
   .:
     dependencies:
+      commander:
+        specifier: ^12.1.0
+        version: 12.1.0
       graphql-request:
         specifier: ^7.2.0
         version: 7.4.0(graphql@16.12.0)
@@ -20,6 +23,9 @@ importers:
       zod:
         specifier: ^3.25.76
         version: 3.25.76
+      zod-to-json-schema:
+        specifier: ^3.25.2
+        version: 3.25.2(zod@3.25.76)
     devDependencies:
       '@eslint/js':
         specifier: ^10.0.1
@@ -30,9 +36,6 @@ importers:
       '@vitest/coverage-v8':
         specifier: ^1.0.0
         version: 1.6.1(vitest@1.6.1(@types/node@20.19.27))
-      commander:
-        specifier: ^12.1.0
-        version: 12.1.0
       dotenv:
         specifier: ^17.2.0
         version: 17.2.3
@@ -953,7 +956,7 @@ packages:
 
   glob@7.2.3:
     resolution: {integrity: sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==}
-    deprecated: Glob versions prior to v9 are no longer supported
+    deprecated: Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
 
   graphql-request@7.4.0:
     resolution: {integrity: sha512-xfr+zFb/QYbs4l4ty0dltqiXIp07U6sl+tOKAb0t50/EnQek6CVVBLjETXi+FghElytvgaAWtIOt3EV7zLzIAQ==}
@@ -1482,6 +1485,11 @@ packages:
   yocto-queue@1.2.2:
     resolution: {integrity: sha512-4LCcse/U2MHZ63HAJVE+v71o7yOdIe4cZ70Wpf8D/IyjDKYQLV5GD46B+hSTjJsvV5PztjvHoU580EftxjDZFQ==}
     engines: {node: '>=12.20'}
+
+  zod-to-json-schema@3.25.2:
+    resolution: {integrity: sha512-O/PgfnpT1xKSDeQYSCfRI5Gy3hPf91mKVDuYLUHZJMiDFptvP41MSnWofm8dnCm0256ZNfZIM7DSzuSMAFnjHA==}
+    peerDependencies:
+      zod: ^3.25.28 || ^4
 
   zod@3.25.76:
     resolution: {integrity: sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==}
@@ -2766,5 +2774,9 @@ snapshots:
   yocto-queue@0.1.0: {}
 
   yocto-queue@1.2.2: {}
+
+  zod-to-json-schema@3.25.2(zod@3.25.76):
+    dependencies:
+      zod: 3.25.76
 
   zod@3.25.76: {}

--- a/src/accounts.types.ts
+++ b/src/accounts.types.ts
@@ -108,10 +108,13 @@ export const GetAccountsResponseSchema = z
 export type GetAccountsResponse = z.infer<typeof GetAccountsResponseSchema>;
 
 // Filters input (aligns with AccountFilters seen in traffic)
-export type AccountFiltersInput = Partial<{
-  accountType: string;
-  includeManual: boolean;
-  includeHidden: boolean;
-  ignoreHiddenFromNetWorth: boolean;
-}> &
-  Record<string, unknown>;
+export const AccountFiltersInputSchema = z
+  .object({
+    accountType: z.string().optional(),
+    includeManual: z.boolean().optional(),
+    includeHidden: z.boolean().optional(),
+    ignoreHiddenFromNetWorth: z.boolean().optional(),
+  })
+  .catchall(z.unknown());
+
+export type AccountFiltersInput = z.infer<typeof AccountFiltersInputSchema>;

--- a/src/budget.types.ts
+++ b/src/budget.types.ts
@@ -520,9 +520,13 @@ export type BudgetSettings = z.infer<typeof BudgetSettingsSchema>;
 /**
  * Input parameters for fetching budget report data
  */
-export interface BudgetReportInput {
-  /** Start month in YYYY-MM-DD format (e.g., "2025-12-01") */
-  startDate: string;
-  /** End month in YYYY-MM-DD format (e.g., "2026-03-01") */
-  endDate: string;
-}
+export const BudgetReportInputSchema = z
+  .object({
+    /** Start month in YYYY-MM-DD format (e.g., "2025-12-01") */
+    startDate: z.string().min(1),
+    /** End month in YYYY-MM-DD format (e.g., "2026-03-01") */
+    endDate: z.string().min(1),
+  })
+  .strict();
+
+export type BudgetReportInput = z.infer<typeof BudgetReportInputSchema>;

--- a/src/cli/auth.ts
+++ b/src/cli/auth.ts
@@ -1,0 +1,204 @@
+import { EmailPasswordAuthProvider, FixedTokenAuthProvider, type AuthProvider } from '../auth.js';
+import { existsSync, mkdirSync, readFileSync, rmSync, writeFileSync, chmodSync } from 'fs';
+import { homedir } from 'os';
+import path from 'path';
+import { z } from 'zod';
+
+import { CliError } from './output.js';
+
+export function createAuthProvider(env: NodeJS.ProcessEnv = process.env): AuthProvider {
+  const token = env.MONARCH_TOKEN;
+  if (token) {
+    return new FixedTokenAuthProvider(token);
+  }
+
+  const cached = readAuthState(env);
+  const email = env.MONARCH_EMAIL;
+  const password = env.MONARCH_PASSWORD;
+  if (email && password) {
+    return new EmailPasswordAuthProvider({
+      email,
+      password,
+      totpKey: env.MONARCH_OTP_KEY,
+      token: cached?.token,
+      tokenExpiresAtMs: cached?.tokenExpiresAtMs,
+      onTokenUpdate: async (newToken, tokenExpiresAtMs) => {
+        writeAuthState(
+          {
+            token: newToken,
+            tokenExpiresAtMs,
+            email,
+            updatedAt: new Date().toISOString(),
+          },
+          env,
+        );
+      },
+    });
+  }
+
+  if (cached && isCachedTokenUsable(cached)) {
+    return new CachedTokenAuthProvider(cached, env);
+  }
+
+  if (cached) {
+    throw new CliError(
+      'AUTH_EXPIRED',
+      'Cached Monarch token is expired. Run `monarch-money auth login`, or set MONARCH_EMAIL and MONARCH_PASSWORD so the CLI can refresh it.',
+      2,
+      {
+        path: getAuthStatePath(env),
+        tokenExpiresAtMs: cached.tokenExpiresAtMs,
+      },
+    );
+  }
+
+  throw new CliError(
+    'AUTH_REQUIRED',
+    'Run `monarch-money auth login`, set MONARCH_TOKEN, or set MONARCH_EMAIL and MONARCH_PASSWORD with optional MONARCH_OTP_KEY.',
+    2,
+  );
+}
+
+const AuthStateSchema = z
+  .object({
+    token: z.string().min(1),
+    tokenExpiresAtMs: z.number().optional(),
+    email: z.string().optional(),
+    updatedAt: z.string().optional(),
+  })
+  .strict();
+
+export type AuthState = z.infer<typeof AuthStateSchema>;
+
+class CachedTokenAuthProvider implements AuthProvider {
+  private token: string | undefined;
+
+  constructor(
+    state: AuthState,
+    private readonly env: NodeJS.ProcessEnv,
+  ) {
+    this.token = state.token;
+  }
+
+  async getToken(): Promise<string> {
+    if (!this.token) {
+      throw new CliError(
+        'AUTH_EXPIRED',
+        'Cached Monarch token is no longer usable. Run `monarch-money auth login`.',
+        2,
+        { path: getAuthStatePath(this.env) },
+      );
+    }
+
+    return this.token;
+  }
+
+  async invalidate(): Promise<void> {
+    this.token = undefined;
+    clearAuthState(this.env);
+  }
+}
+
+export function getAuthStatePath(env: NodeJS.ProcessEnv = process.env): string {
+  return resolveHome(env.MONARCH_AUTH_FILE ?? '~/.monarch-money/auth.json');
+}
+
+export function readAuthState(env: NodeJS.ProcessEnv = process.env): AuthState | undefined {
+  const file = getAuthStatePath(env);
+  if (!existsSync(file)) return undefined;
+
+  try {
+    return AuthStateSchema.parse(JSON.parse(readFileSync(file, 'utf8')));
+  } catch (cause) {
+    throw new CliError(
+      'AUTH_STATE_INVALID',
+      `Could not read Monarch auth state at ${file}: ${
+        cause instanceof Error ? cause.message : String(cause)
+      }`,
+      2,
+    );
+  }
+}
+
+export function writeAuthState(state: AuthState, env: NodeJS.ProcessEnv = process.env): void {
+  const file = getAuthStatePath(env);
+  mkdirSync(path.dirname(file), { recursive: true, mode: 0o700 });
+  writeFileSync(file, JSON.stringify(state, null, 2) + '\n', { mode: 0o600 });
+  chmodSync(file, 0o600);
+}
+
+export function clearAuthState(env: NodeJS.ProcessEnv = process.env): boolean {
+  const file = getAuthStatePath(env);
+  if (!existsSync(file)) return false;
+  rmSync(file);
+  return true;
+}
+
+export async function loginAndCacheAuthState(
+  env: NodeJS.ProcessEnv = process.env,
+): Promise<Omit<AuthState, 'token'>> {
+  const email = env.MONARCH_EMAIL;
+  const password = env.MONARCH_PASSWORD;
+  if (!email || !password) {
+    throw new CliError(
+      'LOGIN_CREDENTIALS_REQUIRED',
+      'Set MONARCH_EMAIL and MONARCH_PASSWORD with optional MONARCH_OTP_KEY before running auth login.',
+      2,
+    );
+  }
+
+  const provider = new EmailPasswordAuthProvider({
+    email,
+    password,
+    totpKey: env.MONARCH_OTP_KEY,
+    onTokenUpdate: async (token, tokenExpiresAtMs) => {
+      writeAuthState(
+        {
+          token,
+          tokenExpiresAtMs,
+          email,
+          updatedAt: new Date().toISOString(),
+        },
+        env,
+      );
+    },
+  });
+
+  await provider.getToken();
+  const state = readAuthState(env);
+  if (!state) {
+    throw new CliError(
+      'AUTH_STATE_WRITE_FAILED',
+      'Login succeeded but auth state was not written.',
+      2,
+    );
+  }
+
+  return {
+    tokenExpiresAtMs: state.tokenExpiresAtMs,
+    email: state.email,
+    updatedAt: state.updatedAt,
+  };
+}
+
+export function getAuthStatus(env: NodeJS.ProcessEnv = process.env): Record<string, unknown> {
+  const state = readAuthState(env);
+  return {
+    path: getAuthStatePath(env),
+    exists: Boolean(state),
+    email: state?.email,
+    updatedAt: state?.updatedAt,
+    tokenExpiresAtMs: state?.tokenExpiresAtMs,
+    usable: state ? isCachedTokenUsable(state) : false,
+  };
+}
+
+function isCachedTokenUsable(state: AuthState): boolean {
+  return !state.tokenExpiresAtMs || Date.now() + 60_000 < state.tokenExpiresAtMs;
+}
+
+function resolveHome(file: string): string {
+  if (file === '~') return homedir();
+  if (file.startsWith('~/')) return path.join(homedir(), file.slice(2));
+  return path.resolve(file);
+}

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -1,0 +1,456 @@
+#!/usr/bin/env node
+import { Command } from 'commander';
+import { z } from 'zod';
+import { zodToJsonSchema } from 'zod-to-json-schema';
+
+import { getAccounts } from '../accounts.api.js';
+import { AccountFiltersInputSchema, AccountSchema } from '../accounts.types.js';
+import {
+  getBudgetCategory,
+  getBudgetCategoryGroups,
+  getBudgetCategories,
+} from '../categories.api.js';
+import {
+  BudgetCategoryDetailSchema,
+  BudgetCategoryGroupWithBudgetingSchema,
+  ManageCategoryGroupsResponseSchema,
+} from '../categories.types.js';
+import { getBudgetReport, getBudgetSettings, getBudgetStatus } from '../budget.api.js';
+import {
+  BudgetReportInputSchema,
+  BudgetReportSchema,
+  BudgetSettingsSchema,
+  BudgetStatusSchema,
+} from '../budget.types.js';
+import { MonarchGraphQLClient } from '../graphql.js';
+import { getPortfolio } from '../portfolio.api.js';
+import { PortfolioInputSchema, PortfolioSchema } from '../portfolio.types.js';
+import { getTransactionRules, previewTransactionRule } from '../rules.api.js';
+import {
+  PreviewTransactionRuleOptionsSchema,
+  TransactionRulePreviewInputSchema as RulePreviewInputSchema,
+  TransactionRulePreviewSchema,
+  TransactionRuleSchema,
+} from '../rules.types.js';
+import { getTransaction, getTransactions, updateTransaction } from '../transactions.api.js';
+import {
+  GetTransactionOptionsSchema,
+  GetTransactionsOptionsSchema,
+  TransactionSchema,
+  UpdateTransactionInputSchema,
+} from '../transactions.types.js';
+
+import {
+  clearAuthState,
+  createAuthProvider,
+  getAuthStatePath,
+  getAuthStatus,
+  loginAndCacheAuthState,
+} from './auth.js';
+import { CliError, writeError, writeSuccess } from './output.js';
+
+type CommandHandler<TInput> = (input: TInput) => Promise<unknown>;
+
+const JsonObjectSchema = z.record(z.unknown());
+const OptionalInputSchema = JsonObjectSchema.optional().default({});
+const EmptyInputSchema = z.object({}).strict().default({});
+
+const GetBudgetCategoryInputSchema = z
+  .object({
+    categoryId: z.string().min(1),
+  })
+  .strict();
+
+const AccountsListOutputSchema = z.array(AccountSchema);
+const TransactionsListOutputSchema = z
+  .object({
+    transactions: z.array(TransactionSchema),
+    totalCount: z.number(),
+    totalSelectableCount: z.number(),
+    transactionRuleIds: z.array(z.string()),
+  })
+  .strict();
+const CategoriesGroupsOutputSchema = z.array(BudgetCategoryGroupWithBudgetingSchema);
+const TransactionRulesOutputSchema = z.array(TransactionRuleSchema);
+
+const PreviewTransactionRuleInputSchema = z
+  .object({
+    rule: RulePreviewInputSchema,
+    options: PreviewTransactionRuleOptionsSchema.optional(),
+  })
+  .strict();
+
+const schemaRegistry = new Map<string, z.ZodTypeAny>([
+  ['input.empty', EmptyInputSchema],
+  ['input.object', JsonObjectSchema],
+  ['input.accounts.list', AccountFiltersInputSchema],
+  ['input.transactions.list', GetTransactionsOptionsSchema],
+  ['input.transaction.get', GetTransactionOptionsSchema],
+  ['input.transaction.update', UpdateTransactionInputSchema],
+  ['input.category.get', GetBudgetCategoryInputSchema],
+  ['input.portfolio', PortfolioInputSchema],
+  ['input.budget.report', BudgetReportInputSchema],
+  ['input.rule.preview', PreviewTransactionRuleInputSchema],
+  ['output.auth.metadata', JsonObjectSchema],
+  ['output.accounts.list', AccountsListOutputSchema],
+  ['output.transactions.list', TransactionsListOutputSchema],
+  ['output.transaction', TransactionSchema],
+  ['output.transaction.nullable', TransactionSchema.nullable()],
+  ['output.categories.list', ManageCategoryGroupsResponseSchema],
+  ['output.categories.groups', CategoriesGroupsOutputSchema],
+  ['output.category.detail', BudgetCategoryDetailSchema],
+  ['output.budget.report', BudgetReportSchema],
+  ['output.budget.status', BudgetStatusSchema],
+  ['output.budget.settings', BudgetSettingsSchema],
+  ['output.portfolio', PortfolioSchema],
+  ['output.rules.list', TransactionRulesOutputSchema],
+  ['output.rule.preview', TransactionRulePreviewSchema],
+]);
+
+const program = new Command();
+
+program
+  .name('monarch-money')
+  .description('Command line interface for the monarch-money-ts API')
+  .version('0.1.0');
+
+program.configureOutput({
+  outputError: (message) => {
+    process.stderr.write(message);
+  },
+});
+
+const schemas = program.command('schemas').description('JSON schema registry');
+schemas
+  .command('list')
+  .description('List named JSON schemas')
+  .action(() => {
+    writeSuccess(Array.from(schemaRegistry.keys()).sort());
+  });
+schemas
+  .command('get')
+  .description('Print a named JSON schema')
+  .argument('<name>', 'Schema name from `monarch-money schemas list`')
+  .action((name: string) => {
+    try {
+      const schema = schemaRegistry.get(name);
+      if (!schema) {
+        throw new CliError('SCHEMA_NOT_FOUND', `Unknown schema: ${name}`, 1, {
+          availableSchemas: Array.from(schemaRegistry.keys()).sort(),
+        });
+      }
+      writeSuccess(toJsonSchema(schema, name));
+    } catch (error) {
+      process.exitCode = writeError(error);
+    }
+  });
+
+const authCommand = program.command('auth').description('Authentication state');
+const authLogin = authCommand
+  .command('login')
+  .description('Log in with MONARCH_EMAIL/MONARCH_PASSWORD and cache the session token')
+  .action(async () => {
+    try {
+      const state = await loginAndCacheAuthState();
+      writeSuccess({
+        path: getAuthStatePath(),
+        ...state,
+      });
+    } catch (error) {
+      process.exitCode = writeError(error);
+    }
+  });
+addSchemaHelp(authLogin, 'input.empty', 'output.auth.metadata');
+
+const authStatus = authCommand
+  .command('status')
+  .description('Show cached authentication state metadata')
+  .action(() => {
+    try {
+      writeSuccess(getAuthStatus());
+    } catch (error) {
+      process.exitCode = writeError(error);
+    }
+  });
+addSchemaHelp(authStatus, 'input.empty', 'output.auth.metadata');
+
+const authLogout = authCommand
+  .command('logout')
+  .description('Remove cached authentication state')
+  .action(() => {
+    try {
+      writeSuccess({
+        path: getAuthStatePath(),
+        removed: clearAuthState(),
+      });
+    } catch (error) {
+      process.exitCode = writeError(error);
+    }
+  });
+addSchemaHelp(authLogout, 'input.empty', 'output.auth.metadata');
+
+const accounts = program.command('accounts').description('Accounts API');
+const accountsList = accounts
+  .command('list')
+  .description('List accounts')
+  .argument('[input]', 'JSON account filters')
+  .action(
+    runCommand(AccountFiltersInputSchema, async (filters) => {
+      const { auth, client } = createContext();
+      return getAccounts(auth, client, filters);
+    }),
+  );
+addSchemaHelp(accountsList, 'input.accounts.list', 'output.accounts.list');
+
+const transactions = program.command('transactions').description('Transactions API');
+const transactionsList = transactions
+  .command('list')
+  .description('List transactions')
+  .argument('[input]', 'JSON options with filters, pagination, and ordering')
+  .action(
+    runCommand(GetTransactionsOptionsSchema, async (input) => {
+      const { auth, client } = createContext();
+      return getTransactions(auth, client, input);
+    }),
+  );
+addSchemaHelp(transactionsList, 'input.transactions.list', 'output.transactions.list');
+
+const transactionsGet = transactions
+  .command('get')
+  .description('Get a transaction by ID')
+  .argument('[input]', 'JSON input: {"id":"...","redirectPosted":true}')
+  .action(
+    runCommand(GetTransactionOptionsSchema, async (input) => {
+      const { auth, client } = createContext();
+      return getTransaction(auth, client, input);
+    }),
+  );
+addSchemaHelp(transactionsGet, 'input.transaction.get', 'output.transaction.nullable');
+
+const transactionsUpdate = transactions
+  .command('update')
+  .description('Update a transaction')
+  .argument('[input]', 'JSON update input including transaction id')
+  .action(
+    runCommand(UpdateTransactionInputSchema, async (input) => {
+      const { auth, client } = createContext();
+      return updateTransaction(auth, client, input);
+    }),
+  );
+addSchemaHelp(transactionsUpdate, 'input.transaction.update', 'output.transaction');
+
+const categories = program.command('categories').description('Categories API');
+const categoriesList = categories
+  .command('list')
+  .description('List budget categories and groups')
+  .action(
+    runCommand(OptionalInputSchema, async () => {
+      const { auth, client } = createContext();
+      return getBudgetCategories(auth, client);
+    }),
+  );
+addSchemaHelp(categoriesList, 'input.empty', 'output.categories.list');
+
+const categoriesGroups = categories
+  .command('groups')
+  .description('List budget category groups with budgeting metadata')
+  .action(
+    runCommand(OptionalInputSchema, async () => {
+      const { auth, client } = createContext();
+      return getBudgetCategoryGroups(auth, client);
+    }),
+  );
+addSchemaHelp(categoriesGroups, 'input.empty', 'output.categories.groups');
+
+const categoriesGet = categories
+  .command('get')
+  .description('Get budget category detail')
+  .argument('[input]', 'JSON input: {"categoryId":"..."}')
+  .action(
+    runCommand(GetBudgetCategoryInputSchema, async ({ categoryId }) => {
+      const { auth, client } = createContext();
+      return getBudgetCategory(auth, client, categoryId);
+    }),
+  );
+addSchemaHelp(categoriesGet, 'input.category.get', 'output.category.detail');
+
+const budget = program.command('budget').description('Budget API');
+const budgetReport = budget
+  .command('report')
+  .description('Get budget report')
+  .argument('[input]', 'JSON input: {"startDate":"YYYY-MM-DD","endDate":"YYYY-MM-DD"}')
+  .action(
+    runCommand(BudgetReportInputSchema, async (input) => {
+      const { auth, client } = createContext();
+      return getBudgetReport(auth, client, input);
+    }),
+  );
+addSchemaHelp(budgetReport, 'input.budget.report', 'output.budget.report');
+
+const budgetStatus = budget
+  .command('status')
+  .description('Get budget status')
+  .action(
+    runCommand(OptionalInputSchema, async () => {
+      const { auth, client } = createContext();
+      return getBudgetStatus(auth, client);
+    }),
+  );
+addSchemaHelp(budgetStatus, 'input.empty', 'output.budget.status');
+
+const budgetSettings = budget
+  .command('settings')
+  .description('Get budget settings')
+  .action(
+    runCommand(OptionalInputSchema, async () => {
+      const { auth, client } = createContext();
+      return getBudgetSettings(auth, client);
+    }),
+  );
+addSchemaHelp(budgetSettings, 'input.empty', 'output.budget.settings');
+
+const portfolio = program
+  .command('portfolio')
+  .description('Get portfolio')
+  .argument('[input]', 'JSON portfolio input')
+  .action(
+    runCommand(PortfolioInputSchema, async (input) => {
+      const { auth, client } = createContext();
+      return getPortfolio(auth, client, input);
+    }),
+  );
+addSchemaHelp(portfolio, 'input.portfolio', 'output.portfolio');
+
+const rules = program.command('rules').description('Transaction rules API');
+const rulesList = rules
+  .command('list')
+  .description('List transaction rules')
+  .action(
+    runCommand(OptionalInputSchema, async () => {
+      const { auth, client } = createContext();
+      return getTransactionRules(auth, client);
+    }),
+  );
+addSchemaHelp(rulesList, 'input.empty', 'output.rules.list');
+
+const rulesPreview = rules
+  .command('preview')
+  .description('Preview a transaction rule')
+  .argument('[input]', 'JSON input: {"rule":{...},"options":{"limit":30}}')
+  .action(
+    runCommand(PreviewTransactionRuleInputSchema, async ({ rule, options }) => {
+      const { auth, client } = createContext();
+      return previewTransactionRule(auth, client, rule, options);
+    }),
+  );
+addSchemaHelp(rulesPreview, 'input.rule.preview', 'output.rule.preview');
+
+program.exitOverride();
+
+program.parseAsync(process.argv).catch((error: unknown) => {
+  if (isCommanderInformationalExit(error)) {
+    process.exitCode = 0;
+    return;
+  }
+  process.exitCode = writeError(error);
+});
+
+function createContext(): {
+  auth: ReturnType<typeof createAuthProvider>;
+  client: MonarchGraphQLClient;
+} {
+  return {
+    auth: createAuthProvider(),
+    client: new MonarchGraphQLClient(process.env.MONARCH_GRAPHQL_ENDPOINT),
+  };
+}
+
+function runCommand<TInput>(
+  schema: z.ZodType<TInput>,
+  handler: CommandHandler<TInput>,
+): (input?: string) => Promise<void> {
+  return async (input?: string) => {
+    try {
+      const rawInput = await parseInput(input);
+      const parsed = schema.safeParse(rawInput);
+      if (!parsed.success) {
+        throw new CliError(
+          'INVALID_INPUT',
+          'Command input did not match the expected JSON shape.',
+          1,
+          {
+            issues: parsed.error.issues,
+          },
+        );
+      }
+      const data = await handler(parsed.data);
+      writeSuccess(data);
+    } catch (error) {
+      process.exitCode = writeError(error);
+    }
+  };
+}
+
+async function parseInput(input: string | undefined): Promise<unknown> {
+  const fromStdin = input === '-';
+  const json = fromStdin ? await readStdin() : input;
+  if (json === undefined || json.trim() === '') {
+    if (fromStdin) {
+      throw new CliError('EMPTY_INPUT', 'Expected JSON on stdin because input was "-".', 1);
+    }
+    return {};
+  }
+  try {
+    return JSON.parse(json);
+  } catch (cause) {
+    throw new CliError(
+      'INVALID_JSON',
+      `Could not parse input as JSON: ${cause instanceof Error ? cause.message : String(cause)}`,
+      1,
+    );
+  }
+}
+
+async function readStdin(): Promise<string> {
+  let data = '';
+  process.stdin.setEncoding('utf8');
+  for await (const chunk of process.stdin) {
+    data += chunk;
+  }
+  return data;
+}
+
+function addSchemaHelp(command: Command, inputSchemaName: string, outputSchemaName: string): void {
+  command.addHelpText('after', () =>
+    [
+      '',
+      'Schemas:',
+      `  input:  ${inputSchemaName}`,
+      `  output: ${outputSchemaName}`,
+      '',
+      `Print a schema with: monarch-money schemas get ${inputSchemaName}`,
+    ].join('\n'),
+  );
+}
+
+function toJsonSchema(schema: z.ZodTypeAny, name: string): unknown {
+  const convert = zodToJsonSchema as unknown as (
+    schema: z.ZodTypeAny,
+    options: { name: string },
+  ) => unknown;
+  return convert(schema, { name });
+}
+
+function isCommanderInformationalExit(error: unknown): boolean {
+  const code =
+    typeof error === 'object' && error !== null && 'code' in error
+      ? (error as { code?: unknown }).code
+      : undefined;
+  const message = error instanceof Error ? error.message : undefined;
+  return (
+    code === 'commander.helpDisplayed' ||
+    code === 'commander.version' ||
+    code === 'commander.versionDisplayed' ||
+    message === '(outputHelp)'
+  );
+}

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -368,9 +368,10 @@ function createContext(): {
 function runCommand<TInput>(
   schema: z.ZodType<TInput>,
   handler: CommandHandler<TInput>,
-): (input?: string) => Promise<void> {
-  return async (input?: string) => {
+): (...args: unknown[]) => Promise<void> {
+  return async (...args: unknown[]) => {
     try {
+      const input = typeof args[0] === 'string' ? args[0] : undefined;
       const rawInput = await parseInput(input);
       const parsed = schema.safeParse(rawInput);
       if (!parsed.success) {

--- a/src/cli/output.ts
+++ b/src/cli/output.ts
@@ -1,0 +1,60 @@
+export class CliError extends Error {
+  readonly code: string;
+  readonly exitCode: number;
+  readonly details?: unknown;
+
+  constructor(code: string, message: string, exitCode = 1, details?: unknown) {
+    super(message);
+    this.name = 'CliError';
+    this.code = code;
+    this.exitCode = exitCode;
+    this.details = details;
+  }
+}
+
+export function writeSuccess(data: unknown): void {
+  process.stdout.write(
+    JSON.stringify(
+      {
+        ok: true,
+        data,
+      },
+      null,
+      2,
+    ) + '\n',
+  );
+}
+
+export function writeError(error: unknown): number {
+  const cliError =
+    error instanceof CliError
+      ? error
+      : new CliError(
+          'COMMAND_FAILED',
+          error instanceof Error ? error.message : String(error),
+          classifyExitCode(error),
+        );
+
+  const payload: Record<string, unknown> = {
+    ok: false,
+    error: {
+      code: cliError.code,
+      message: cliError.message,
+      ...(cliError.details === undefined ? {} : { details: cliError.details }),
+    },
+  };
+
+  process.stderr.write(JSON.stringify(payload, null, 2) + '\n');
+  return cliError.exitCode;
+}
+
+function classifyExitCode(error: unknown): number {
+  if (error instanceof Error) {
+    const message = error.message.toLowerCase();
+    if (/auth|token|login|credential|mfa/.test(message)) return 2;
+    if (/graphql|mutation|api/.test(message)) return 3;
+    if (/zod|schema|validation|parse/.test(message)) return 4;
+    if (/network|fetch|rate|timeout|429/.test(message)) return 5;
+  }
+  return 1;
+}

--- a/src/portfolio.types.ts
+++ b/src/portfolio.types.ts
@@ -234,11 +234,14 @@ export type GetPortfolioResponse = z.infer<typeof GetPortfolioResponseSchema>;
  * - includeHiddenHoldings: include hidden holdings
  * - topMoversLimit: limit for top movers (used by web UI)
  */
-export type PortfolioInput = Partial<{
-  accountIds: string[];
-  includeHiddenHoldings: boolean;
-  startDate: string;
-  endDate: string;
-  topMoversLimit: number;
-}> &
-  Record<string, unknown>;
+export const PortfolioInputSchema = z
+  .object({
+    accountIds: z.array(z.string()).optional(),
+    includeHiddenHoldings: z.boolean().optional(),
+    startDate: z.string().optional(),
+    endDate: z.string().optional(),
+    topMoversLimit: z.number().int().positive().optional(),
+  })
+  .catchall(z.unknown());
+
+export type PortfolioInput = z.infer<typeof PortfolioInputSchema>;

--- a/src/rules.types.ts
+++ b/src/rules.types.ts
@@ -361,35 +361,57 @@ export type GetTransactionRulesResponse = z.infer<typeof GetTransactionRulesResp
  * Input for previewing which transactions a rule would match.
  * Mirrors TransactionRulePreviewInput from the GraphQL schema.
  */
-export type TransactionRulePreviewInput = {
-  merchantCriteriaUseOriginalStatement?: boolean;
-  merchantCriteria?: Array<{ operator: string; value: string }>;
-  merchantNameCriteria?: Array<{ operator: string; value: string }>;
-  originalStatementCriteria?: Array<{ operator: string; value: string }>;
-  amountCriteria?: {
-    operator: string;
-    isExpense: boolean;
-    value?: number | null;
-    valueRange?: { lower: number; upper: number } | null;
-  } | null;
-  categoryIds?: string[];
-  accountIds?: string[];
-  criteriaOwnerIsJoint?: boolean;
-  criteriaOwnerUserIds?: string[];
-  // Actions
-  setCategoryAction?: string;
-  setMerchantAction?: string;
-  addTagsAction?: string[];
-  linkGoalAction?: string;
-  needsReviewByUserAction?: string;
-  unassignNeedsReviewByUserAction?: boolean;
-  sendNotificationAction?: boolean;
-  setHideFromReportsAction?: boolean;
-  reviewStatusAction?: string;
-  actionSetOwnerIsJoint?: boolean;
-  actionSetOwner?: string;
-  applyToExistingTransactions?: boolean;
-};
+const RuleCriterionInputSchema = z
+  .object({
+    operator: z.string(),
+    value: z.string(),
+  })
+  .strict();
+
+export const TransactionRulePreviewInputSchema = z
+  .object({
+    merchantCriteriaUseOriginalStatement: z.boolean().optional(),
+    merchantCriteria: z.array(RuleCriterionInputSchema).optional(),
+    merchantNameCriteria: z.array(RuleCriterionInputSchema).optional(),
+    originalStatementCriteria: z.array(RuleCriterionInputSchema).optional(),
+    amountCriteria: z
+      .object({
+        operator: z.string(),
+        isExpense: z.boolean(),
+        value: z.number().nullable().optional(),
+        valueRange: z
+          .object({
+            lower: z.number(),
+            upper: z.number(),
+          })
+          .strict()
+          .nullable()
+          .optional(),
+      })
+      .strict()
+      .nullable()
+      .optional(),
+    categoryIds: z.array(z.string()).optional(),
+    accountIds: z.array(z.string()).optional(),
+    criteriaOwnerIsJoint: z.boolean().optional(),
+    criteriaOwnerUserIds: z.array(z.string()).optional(),
+    // Actions
+    setCategoryAction: z.string().optional(),
+    setMerchantAction: z.string().optional(),
+    addTagsAction: z.array(z.string()).optional(),
+    linkGoalAction: z.string().optional(),
+    needsReviewByUserAction: z.string().optional(),
+    unassignNeedsReviewByUserAction: z.boolean().optional(),
+    sendNotificationAction: z.boolean().optional(),
+    setHideFromReportsAction: z.boolean().optional(),
+    reviewStatusAction: z.string().optional(),
+    actionSetOwnerIsJoint: z.boolean().optional(),
+    actionSetOwner: z.string().optional(),
+    applyToExistingTransactions: z.boolean().optional(),
+  })
+  .strict();
+
+export type TransactionRulePreviewInput = z.infer<typeof TransactionRulePreviewInputSchema>;
 
 // ---------------- Preview Transaction Rule Response ----------------
 
@@ -486,7 +508,11 @@ export type PreviewTransactionRuleResponse = z.infer<typeof PreviewTransactionRu
 /**
  * Options for previewTransactionRule function.
  */
-export interface PreviewTransactionRuleOptions {
-  offset?: number;
-  limit?: number;
-}
+export const PreviewTransactionRuleOptionsSchema = z
+  .object({
+    offset: z.number().int().min(0).optional(),
+    limit: z.number().int().positive().optional(),
+  })
+  .strict();
+
+export type PreviewTransactionRuleOptions = z.infer<typeof PreviewTransactionRuleOptionsSchema>;

--- a/src/transactions.types.ts
+++ b/src/transactions.types.ts
@@ -151,35 +151,42 @@ export type GetTransactionsResponse = z.infer<typeof GetTransactionsResponseSche
  * Filters for transactions query (aligns with TransactionFilterInput in GraphQL).
  * All fields are optional to allow flexible filtering.
  */
-export type TransactionFiltersInput = Partial<{
-  search: string;
-  accountIds: string[];
-  categoryIds: string[];
-  merchantIds: string[];
-  tagIds: string[];
-  goalIds: string[];
-  startDate: string; // YYYY-MM-DD
-  endDate: string; // YYYY-MM-DD
-  amount: number;
-  amountOperator: string; // "lt" | "lte" | "eq" | "gte" | "gt"
-  isPending: boolean; // Note: filter uses isPending, but Transaction type has pending field
-  hideFromReports: boolean;
-  needsReview: boolean;
-  isRecurring: boolean;
-  isSplitTransaction: boolean;
-  transactionVisibility: string; // "non_hidden_transactions_only" | "hidden_transactions_only" | "all_transactions"
-}> &
-  Record<string, unknown>;
+export const TransactionFiltersInputSchema = z
+  .object({
+    search: z.string().optional(),
+    accountIds: z.array(z.string()).optional(),
+    categoryIds: z.array(z.string()).optional(),
+    merchantIds: z.array(z.string()).optional(),
+    tagIds: z.array(z.string()).optional(),
+    goalIds: z.array(z.string()).optional(),
+    startDate: z.string().optional(), // YYYY-MM-DD
+    endDate: z.string().optional(), // YYYY-MM-DD
+    amount: z.number().optional(),
+    amountOperator: z.string().optional(), // "lt" | "lte" | "eq" | "gte" | "gt"
+    isPending: z.boolean().optional(), // Note: filter uses isPending, but Transaction type has pending field
+    hideFromReports: z.boolean().optional(),
+    needsReview: z.boolean().optional(),
+    isRecurring: z.boolean().optional(),
+    isSplitTransaction: z.boolean().optional(),
+    transactionVisibility: z.string().optional(), // "non_hidden_transactions_only" | "hidden_transactions_only" | "all_transactions"
+  })
+  .catchall(z.unknown());
+
+export type TransactionFiltersInput = z.infer<typeof TransactionFiltersInputSchema>;
 
 /**
  * Options for getTransactions function
  */
-export interface GetTransactionsOptions {
-  offset?: number;
-  limit?: number;
-  orderBy?: string; // "date" | "amount" | etc.
-  filters?: TransactionFiltersInput;
-}
+export const GetTransactionsOptionsSchema = z
+  .object({
+    offset: z.number().int().min(0).optional(),
+    limit: z.number().int().positive().optional(),
+    orderBy: z.string().optional(), // "date" | "amount" | etc.
+    filters: TransactionFiltersInputSchema.optional(),
+  })
+  .strict();
+
+export type GetTransactionsOptions = z.infer<typeof GetTransactionsOptionsSchema>;
 
 // ---------------- Get Single Transaction Response ----------------
 
@@ -205,12 +212,16 @@ export type GetTransactionResponse = z.infer<typeof GetTransactionResponseSchema
 /**
  * Input options for fetching a single transaction.
  */
-export interface GetTransactionOptions {
-  /** Transaction ID to fetch */
-  id: string;
-  /** Whether to redirect posted transactions (optional) */
-  redirectPosted?: boolean;
-}
+export const GetTransactionOptionsSchema = z
+  .object({
+    /** Transaction ID to fetch */
+    id: z.string().min(1),
+    /** Whether to redirect posted transactions (optional) */
+    redirectPosted: z.boolean().optional(),
+  })
+  .strict();
+
+export type GetTransactionOptions = z.infer<typeof GetTransactionOptionsSchema>;
 
 // ---------------- Update Transaction Types ----------------
 
@@ -218,26 +229,30 @@ export interface GetTransactionOptions {
  * Generic input for updating a transaction.
  * All fields except id are optional - only provide the fields you want to update.
  */
-export interface UpdateTransactionInput {
-  /** Transaction ID to update */
-  id: string;
-  /** Category ID to assign */
-  category?: string;
-  /** Whether this is a recommended category (used with category updates) */
-  isRecommendedCategory?: boolean;
-  /** Mark transaction as reviewed (true) or needing review (false) */
-  reviewed?: boolean;
-  /** Mark transaction as needing review */
-  needsReview?: boolean;
-  /** Transaction notes */
-  notes?: string;
-  /** Merchant ID */
-  merchant?: string;
-  /** Hide from reports */
-  hideFromReports?: boolean;
-  /** Tag IDs to assign */
-  tags?: string[];
-}
+export const UpdateTransactionInputSchema = z
+  .object({
+    /** Transaction ID to update */
+    id: z.string().min(1),
+    /** Category ID to assign */
+    category: z.string().optional(),
+    /** Whether this is a recommended category (used with category updates) */
+    isRecommendedCategory: z.boolean().optional(),
+    /** Mark transaction as reviewed (true) or needing review (false) */
+    reviewed: z.boolean().optional(),
+    /** Mark transaction as needing review */
+    needsReview: z.boolean().optional(),
+    /** Transaction notes */
+    notes: z.string().optional(),
+    /** Merchant ID */
+    merchant: z.string().optional(),
+    /** Hide from reports */
+    hideFromReports: z.boolean().optional(),
+    /** Tag IDs to assign */
+    tags: z.array(z.string()).optional(),
+  })
+  .strict();
+
+export type UpdateTransactionInput = z.infer<typeof UpdateTransactionInputSchema>;
 
 /**
  * Response schema for updateTransaction mutation.


### PR DESCRIPTION
## Summary
- Add the published `monarch-money` CLI with JSON input/output commands for the existing API surface.
- Add stateful token-only CLI auth caching via `auth login/status/logout` and configurable `MONARCH_AUTH_FILE`.
- Add named JSON schema discovery and reusable library input schemas, plus CLI docs and changelog coverage.

## Test plan
- `pnpm build`
- `pnpm test`
- `pnpm lint`
- `npm pack --dry-run`


Made with [Cursor](https://cursor.com)